### PR TITLE
Adds docker image for CNI install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,19 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# jetbrains ide stuff
+.idea*
+
+.swp*
+.swo*
+
+
+bin/
+vendor/github.com/
+vendor/golang.org/
+vendor/google.golang.org/
+vendor/gopkg.in/
+vendor/go.uber.org/
+vendor/k8s.io/
+vendor/honnef.co/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: go
+dist: trusty
+go:
+  - 1.11.x
+env:
+  global:
+    secure: "y5J6lS80fafmg/iKVmVxK9zL9QMOB8KVV2EtE7eTj6xJUN0FzF1f2dcUjqp6njYAmwmY7M5/EDtKxjOs8dRNEK4wLGmBwpbjTP+KMUJSP5+tWDxe0CxDcwMGBbbYfegzBQVQY2mlvJ+CNriggLKJt2IbufxUi5wvxrYnl3KjpYhThOfpZBMcLhvCvPiFPY9zjZJxccQcscBnOEUu7AEYoaH3VPhc0LiKDvrr3F0SK+JkyOIzwLT0aNIEEimeNYPwGqbCkod6Anebu+SfDoizR6u2kBbJHYUi+kQusV2VP6tyPNlNGvb+QO2ALE53gNcqfUTPqOWhfwlE8nJoKxv8d0aMC66+QxReaV7RPrms+AToYzLTVN0QMy9ptmno99FBGovG3Q50DqAabMZumwobEzOJeemToFYHlOoQmmdC28cANR4ADHHnG8M8dGSZGFn11YIT9ZMJPh06RtnrMUwNoIbfGCUufVU0tE4sTQZvCBnTOa3ukmlbTZWNF+zdvwsDtsU/R/RvX8z0quAAcLbsJTd/8e7JFE2ZA+lXiauCPqDqcLMay62ZsnpPDy0KlorBuFIjQeesQDC8yVeA4a2O6XiGwPciAsKbiQZySN8H9VCiey463N0JEPNwmD4zzOs/hrL/RFzbFxnDMjkw9NAEqYvEFGNkwnbE5SsOPPJ1BZU="
+
+install:
+  - go get -u golang.org/x/lint/golint
+
+before_script:
+  - set -e
+  - go list ./... | grep -v /proto/ | xargs -n 1 golint
+  - go tool vet  ./cmd/
+  - git ls-files | grep -v proto |grep ".go$" | xargs gofmt -l | wc -l
+
+script:
+  - "./build/build-go.sh"
+  - docker build -t nimbess/cni .
+
+deploy:
+  # Push images to Dockerhub on merge to master
+  - provider: script
+    on:
+      branch: master
+    script: >
+      bash -c '
+      docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS";
+      docker push nimbess/cni:latest;
+      echo done'
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.11
+WORKDIR $GOPATH/src/github.com/nimbess/nimbess-cni
+COPY . .
+RUN ./build/build-go.sh
+
+FROM centos:latest
+COPY --from=0 /go/src/github.com/nimbess/nimbess-cni/k8s/install-cni.sh .
+WORKDIR /opt/cni/bin
+COPY --from=0 /go/src/github.com/nimbess/nimbess-cni/bin/nimbess .
+WORKDIR /

--- a/build/build-go.sh
+++ b/build/build-go.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eu
+eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
+GOOS=${GOOS:-${GOHOSTOS}}
+GOARCH=${GOACH:-${GOHOSTARCH}}
+GOFLAGS=${GOFLAGS:-}
+GLDFLAGS=${GLDFLAGS:-}
+CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go get -u github.com/kardianos/govendor
+CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} govendor sync
+CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/nimbess cmd/nimbess-cni.go

--- a/k8s/install-cni.sh
+++ b/k8s/install-cni.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Script to install Nimbess CNI on a Kubernetes host.
+# - Expects the host CNI binary path to be mounted at /host/opt/cni/bin.
+# - Expects the host CNI network config path to be mounted at /host/etc/cni/net.d.
+# - Expects the desired CNI config in the CNI_NETWORK_CONFIG env variable.
+
+# Ensure all variables are defined, and that the script fails when an error is hit.
+set -u -e
+
+# Capture the usual signals and exit from the script
+trap 'echo "INT received, simply exiting..."; exit 0' INT
+trap 'echo "TERM received, simply exiting..."; exit 0' TERM
+trap 'echo "HUP received, simply exiting..."; exit 0' HUP
+
+# Helper function for raising errors
+# Usage:
+# some_command || exit_with_error "some_command_failed: maybe try..."
+exit_with_error(){
+  echo "$1"
+  exit 1
+}
+
+# The directory on the host where CNI networks are installed. Defaults to
+# /etc/cni/net.d, but can be overridden by setting CNI_NET_DIR.  This is used
+# for populating absolute paths in the CNI network config to assets
+# which are installed in the CNI network config directory.
+HOST_CNI_NET_DIR=${CNI_NET_DIR:-/etc/cni/net.d}
+
+# Clean up any existing binaries / config / assets.
+rm -f /host/opt/cni/bin/nimbess-cni
+
+# Choose which default cni binaries should be copied
+SKIP_CNI_BINARIES=${SKIP_CNI_BINARIES:-""}
+SKIP_CNI_BINARIES=",$SKIP_CNI_BINARIES,"
+UPDATE_CNI_BINARIES=${UPDATE_CNI_BINARIES:-"true"}
+
+# Place the new binaries if the directory is writeable.
+for dir in /host/opt/cni/bin /host/secondary-bin-dir
+do
+  if [ ! -w "$dir" ];
+  then
+    echo "$dir is non-writeable, skipping"
+    continue
+  fi
+  for path in /opt/cni/bin/*;
+  do
+    filename="$(basename "$path")"
+    tmp=",$filename,"
+    if [ "${SKIP_CNI_BINARIES#*$tmp}" != "$SKIP_CNI_BINARIES" ];
+    then
+      echo "$filename is in SKIP_CNI_BINARIES, skipping"
+      continue
+    fi
+    if [ "${UPDATE_CNI_BINARIES}" != "true" ] && [ -f $dir/"$filename" ];
+    then
+      echo "$dir/$filename is already here and UPDATE_CNI_BINARIES isn't true, skipping"
+      continue
+    fi
+    cp "$path" $dir/ || exit_with_error "Failed to copy $path to $dir. This may be caused by selinux configuration on the host, or something else."
+  done
+
+  echo "Wrote Nimbess CNI binaries to $dir"
+done
+
+TMP_CONF='/nimbess.conf.tmp'
+# If specified, overwrite the network configuration file.
+: "${CNI_NETWORK_CONFIG_FILE:=}"
+: "${CNI_NETWORK_CONFIG:=}"
+if [ -e "${CNI_NETWORK_CONFIG_FILE}" ]; then
+  echo "Using CNI config template from ${CNI_NETWORK_CONFIG_FILE}."
+  cp "${CNI_NETWORK_CONFIG_FILE}" "${TMP_CONF}"
+elif [ "${CNI_NETWORK_CONFIG}" != "" ]; then
+  echo "Using CNI config template from CNI_NETWORK_CONFIG environment variable."
+  cat >$TMP_CONF <<EOF
+${CNI_NETWORK_CONFIG}
+EOF
+fi
+
+CNI_CONF_NAME=${CNI_CONF_NAME:-10-nimbess.conf}
+CNI_OLD_CONF_NAME=${CNI_OLD_CONF_NAME:-10-nimbess.conf}
+
+# Log the config file before inserting service account token.
+# This way auth token is not visible in the logs.
+echo "CNI config: $(cat ${TMP_CONF})"
+
+# Move the temporary CNI config into place.
+mv "$TMP_CONF" /host/etc/cni/net.d/"${CNI_CONF_NAME}" || \
+  exit_with_error "Failed to mv files. This may be caused by selinux configuration on the host, or something else."
+
+echo "Created CNI config ${CNI_CONF_NAME}"
+
+# Unless told otherwise, sleep forever.
+# This prevents Kubernetes from restarting the pod repeatedly.
+should_sleep=${SLEEP:-"true"}
+echo "Done configuring CNI.  Sleep=$should_sleep"
+while [ "$should_sleep" = "true"  ]; do
+    sleep 10
+done

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,361 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "wPKiEWFfo1lFKXb7TQW1HffbuP8=",
+			"path": "github.com/containernetworking/cni/pkg/skel",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "Dhi4+8X7U2oVzVkgxPrmLaN8qFI=",
+			"path": "github.com/containernetworking/cni/pkg/types",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "6+ng8oaM9SB0TyCE7I7N940IpPY=",
+			"path": "github.com/containernetworking/cni/pkg/types/020",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "X6dNZ3yc3V9ffW9vz4yIyeKXGD0=",
+			"path": "github.com/containernetworking/cni/pkg/types/current",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "aojwjPoA9XSGB/zVtOGzWvmv/i8=",
+			"path": "github.com/containernetworking/cni/pkg/version",
+			"revision": "dc953e2fd91f9bc624b03cf9ea3706796bfee920",
+			"revisionTime": "2019-06-12T15:24:20Z"
+		},
+		{
+			"checksumSHA1": "LxTzOk0+wIfpgFgyw/HzuLM4H3c=",
+			"path": "github.com/containernetworking/plugins/pkg/utils/buildversion",
+			"revision": "966bbcb8a572aa4c253ea9650888ad2306e3c8f2",
+			"revisionTime": "2019-07-10T15:04:52Z"
+		},
+		{
+			"checksumSHA1": "GaJLoEuMGnP5ofXvuweAI4wx06U=",
+			"path": "github.com/golang/protobuf/proto",
+			"revision": "1918e1ff6ffd2be7bed0553df8650672c3bfe80d",
+			"revisionTime": "2018-10-30T15:47:21Z"
+		},
+		{
+			"checksumSHA1": "tkJPssYejSjuAwE2tdEnoEIj93Q=",
+			"path": "github.com/golang/protobuf/ptypes",
+			"revision": "1918e1ff6ffd2be7bed0553df8650672c3bfe80d",
+			"revisionTime": "2018-10-30T15:47:21Z"
+		},
+		{
+			"checksumSHA1": "UvYEjI10BRTlBOd8fZvQrJbLpC4=",
+			"path": "github.com/golang/protobuf/ptypes/any",
+			"revision": "1918e1ff6ffd2be7bed0553df8650672c3bfe80d",
+			"revisionTime": "2018-10-30T15:47:21Z"
+		},
+		{
+			"checksumSHA1": "GKo6mbuEFhhg/SzB4UpvEB64rDA=",
+			"path": "github.com/golang/protobuf/ptypes/duration",
+			"revision": "1918e1ff6ffd2be7bed0553df8650672c3bfe80d",
+			"revisionTime": "2018-10-30T15:47:21Z"
+		},
+		{
+			"checksumSHA1": "T42CEYmGiqIXTe36UJ5jLPO33lY=",
+			"path": "github.com/golang/protobuf/ptypes/timestamp",
+			"revision": "1918e1ff6ffd2be7bed0553df8650672c3bfe80d",
+			"revisionTime": "2018-10-30T15:47:21Z"
+		},
+		{
+			"checksumSHA1": "sN4FqlRC/l5XDEj56RhsKy6N3bY=",
+			"path": "github.com/nimbess/nimbess-agent/pkg/proto/cni",
+			"revision": "3e24359fca70c4181c0fc0752d199ec5fe65e3fb",
+			"revisionTime": "2019-07-10T16:30:49Z"
+		},
+		{
+			"checksumSHA1": "SVO+Zm6SNwWrpgyc6mcTXbH4aJ8=",
+			"path": "github.com/sirupsen/logrus",
+			"revision": "2a22dbedbad1fd454910cd1f44f210ef90c28464",
+			"revisionTime": "2019-05-18T13:52:02Z"
+		},
+		{
+			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
+			"path": "golang.org/x/net/context",
+			"revision": "c10e9556a7bc0e7c942242b606f0acf024ad5d6a",
+			"revisionTime": "2018-11-02T08:55:01Z"
+		},
+		{
+			"checksumSHA1": "pCY4YtdNKVBYRbNvODjx8hj0hIs=",
+			"path": "golang.org/x/net/http/httpguts",
+			"revision": "c10e9556a7bc0e7c942242b606f0acf024ad5d6a",
+			"revisionTime": "2018-11-02T08:55:01Z"
+		},
+		{
+			"checksumSHA1": "YLw3pc+2ztzrxw6DYNfYYFnSCeo=",
+			"path": "golang.org/x/net/http2",
+			"revision": "c10e9556a7bc0e7c942242b606f0acf024ad5d6a",
+			"revisionTime": "2018-11-02T08:55:01Z"
+		},
+		{
+			"checksumSHA1": "KZniwnfpWkaTPhUQDUTvgex/7y0=",
+			"path": "golang.org/x/net/http2/hpack",
+			"revision": "c10e9556a7bc0e7c942242b606f0acf024ad5d6a",
+			"revisionTime": "2018-11-02T08:55:01Z"
+		},
+		{
+			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
+			"path": "golang.org/x/net/idna",
+			"revision": "c10e9556a7bc0e7c942242b606f0acf024ad5d6a",
+			"revisionTime": "2018-11-02T08:55:01Z"
+		},
+		{
+			"checksumSHA1": "UxahDzW2v4mf/+aFxruuupaoIwo=",
+			"path": "golang.org/x/net/internal/timeseries",
+			"revision": "c10e9556a7bc0e7c942242b606f0acf024ad5d6a",
+			"revisionTime": "2018-11-02T08:55:01Z"
+		},
+		{
+			"checksumSHA1": "6ckrK99wkirarIfFNX4+AHWBEHM=",
+			"path": "golang.org/x/net/trace",
+			"revision": "c10e9556a7bc0e7c942242b606f0acf024ad5d6a",
+			"revisionTime": "2018-11-02T08:55:01Z"
+		},
+		{
+			"checksumSHA1": "BW0KOqvgOUoyFwEQKWTdoEJrR6c=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "9b800f95dbbc54abff0acf7ee32d88ba4e328c89",
+			"revisionTime": "2018-10-31T12:20:39Z"
+		},
+		{
+			"checksumSHA1": "CbpjEkkOeh0fdM/V8xKDdI0AA88=",
+			"path": "golang.org/x/text/secure/bidirule",
+			"revision": "6f44c5a2ea40ee3593d98cdcc905cc1fdaa660e2",
+			"revisionTime": "2018-10-29T18:00:05Z"
+		},
+		{
+			"checksumSHA1": "o3YChxWLvyCmkAn/ZNBj9HC9zKw=",
+			"path": "golang.org/x/text/transform",
+			"revision": "6f44c5a2ea40ee3593d98cdcc905cc1fdaa660e2",
+			"revisionTime": "2018-10-29T18:00:05Z"
+		},
+		{
+			"checksumSHA1": "kRHVIuePi38RXAJmksH3MfQzTJI=",
+			"path": "golang.org/x/text/unicode/bidi",
+			"revision": "6f44c5a2ea40ee3593d98cdcc905cc1fdaa660e2",
+			"revisionTime": "2018-10-29T18:00:05Z"
+		},
+		{
+			"checksumSHA1": "lBB8oUHgIK0RUuDchkQVfMXJQh0=",
+			"path": "golang.org/x/text/unicode/norm",
+			"revision": "6f44c5a2ea40ee3593d98cdcc905cc1fdaa660e2",
+			"revisionTime": "2018-10-29T18:00:05Z"
+		},
+		{
+			"checksumSHA1": "knF2NGI4m3IQSTWMDkd5HDwFXVY=",
+			"path": "google.golang.org/genproto/googleapis/rpc/status",
+			"revision": "64821d5d210748c883cd2b809589555ae4654203",
+			"revisionTime": "2019-04-04T17:22:33Z"
+		},
+		{
+			"checksumSHA1": "V+WkcollpULC2KGIQZAjtXPO5xM=",
+			"path": "google.golang.org/grpc",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "5tiVv51BgOdX40/MLyRvKKXPgzo=",
+			"path": "google.golang.org/grpc/balancer",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "s5cVYZoVo/BWa6+tXoifA+gVu28=",
+			"path": "google.golang.org/grpc/balancer/base",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "cE7mFcyGz0F+EnlTZrzLkhprH/4=",
+			"path": "google.golang.org/grpc/balancer/roundrobin",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "YyTUFAVju8wgb1s/3azC2CeSbfY=",
+			"path": "google.golang.org/grpc/binarylog/grpc_binarylog_v1",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "e0xLHThZgMNcuR7aFuY+pzuQVVU=",
+			"path": "google.golang.org/grpc/codes",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "UgxkVy6e/BMqXrmS21WmcHtdcd4=",
+			"path": "google.golang.org/grpc/connectivity",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "wFNageUqdmmE0U4Zz/mbiDEEXPU=",
+			"path": "google.golang.org/grpc/credentials",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "Eqxca59xIMaL4EUNwWsozg7kFkk=",
+			"path": "google.golang.org/grpc/credentials/internal",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "puS+9H2qFMoLKCyXxu9nGACNuQk=",
+			"path": "google.golang.org/grpc/encoding",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "LKKkn7EYA+Do9Qwb2/SUKLFNxoo=",
+			"path": "google.golang.org/grpc/encoding/proto",
+			"revision": "3507fb8e1a5ad030303c106fef3a47c9fdad16ad",
+			"revisionTime": "2019-03-20T22:36:17Z"
+		},
+		{
+			"checksumSHA1": "3hj3attJzO2iqArJeSNEW8diHqo=",
+			"path": "google.golang.org/grpc/grpclog",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "486t4oLzzaCmJ7Q9m3DagNbgfSc=",
+			"path": "google.golang.org/grpc/internal",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "uDJA7QK2iGnEwbd9TPqkLaM+xuU=",
+			"path": "google.golang.org/grpc/internal/backoff",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "k4ITR7VpzDbbf0tRqI6p9xsmPug=",
+			"path": "google.golang.org/grpc/internal/balancerload",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "Wxgih1pu+wvJRT/rCY9WgSMF4w4=",
+			"path": "google.golang.org/grpc/internal/binarylog",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "YtqLJH9Ht2sD5EqAOSqbARDUeXw=",
+			"path": "google.golang.org/grpc/internal/channelz",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "i4SV6WG1mpU7hw8mtvY5HuXKUCI=",
+			"path": "google.golang.org/grpc/internal/envconfig",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "70gndc/uHwyAl3D45zqp7vyHWlo=",
+			"path": "google.golang.org/grpc/internal/grpcrand",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "psHSfNyU2y9L9zRK+s41e7ScTf4=",
+			"path": "google.golang.org/grpc/internal/grpcsync",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "wTCshPVAgkVAk+4nvDj5Yj6AFp4=",
+			"path": "google.golang.org/grpc/internal/syscall",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "eOMr0yh/VenCFMNDkVxUj8ypI4U=",
+			"path": "google.golang.org/grpc/internal/transport",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "cDYDzrrgfj9Y45GDWcXXCrRofp0=",
+			"path": "google.golang.org/grpc/keepalive",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "0OoJw+Wc7+1Ox5nBbwjgqWW8Xpw=",
+			"path": "google.golang.org/grpc/metadata",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "bk9IupgyMXhqsOBR/dp7ZmRjVEE=",
+			"path": "google.golang.org/grpc/naming",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "ltPJN8UyzvWN0H0BvkP2AREujgQ=",
+			"path": "google.golang.org/grpc/peer",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "Gh13yW3zxiCa1vRGDaWqm1b3/mI=",
+			"path": "google.golang.org/grpc/resolver",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "GDSzPulWXlL1fSZuT65qIBKhk4E=",
+			"path": "google.golang.org/grpc/resolver/dns",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "voz1mta5+d5bXMGt9SK88Vys2iE=",
+			"path": "google.golang.org/grpc/resolver/passthrough",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "k/V72hKZdT/uJ9tkRXybBG/wriE=",
+			"path": "google.golang.org/grpc/serviceconfig",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "3ZPGj/HdfLTiK7I3xPdnqELnHdk=",
+			"path": "google.golang.org/grpc/stats",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "bJSa9mM309wvISy+B6zfc0KAUqs=",
+			"path": "google.golang.org/grpc/status",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		},
+		{
+			"checksumSHA1": "HGXDrPBB90iBU4NJ7C1N8MJRkI0=",
+			"path": "google.golang.org/grpc/tap",
+			"revision": "d33cecdaddaa914130410059cdcca8b3b0176985",
+			"revisionTime": "2019-06-05T17:52:48Z"
+		}
+	],
+	"rootPath": "github.com/nimbess/nimbess-cni"
+}


### PR DESCRIPTION
Travis CI will now run tests and build nimbess-cni docker container
image. The image is uploaded upon merge into master. An install cni
script is added by this patch which allows for k8s to install Nimbess
cni from the docker image. Dependency management also added with
govendor.

Signed-off-by: Tim Rozet <trozet@redhat.com>